### PR TITLE
Support RefFromWasmAbi

### DIFF
--- a/tests/expand/borrow.expanded.rs
+++ b/tests/expand/borrow.expanded.rs
@@ -10,7 +10,10 @@ const _: () = {
     extern crate serde as _serde;
     use tsify::Tsify;
     use wasm_bindgen::{
-        convert::{FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi, OptionIntoWasmAbi},
+        convert::{
+            FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi, OptionIntoWasmAbi,
+            RefFromWasmAbi,
+        },
         describe::WasmDescribe, prelude::*,
     };
     #[wasm_bindgen]
@@ -70,6 +73,23 @@ const _: () = {
         #[inline]
         fn is_none(js: &Self::Abi) -> bool {
             <JsType as OptionFromWasmAbi>::is_none(js)
+        }
+    }
+    pub struct SelfOwner<T>(T);
+    impl<T> ::core::ops::Deref for SelfOwner<T> {
+        type Target = T;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+    impl<'a> RefFromWasmAbi for Borrow<'a>
+    where
+        Self: _serde::de::DeserializeOwned,
+    {
+        type Abi = <JsType as RefFromWasmAbi>::Abi;
+        type Anchor = SelfOwner<Self>;
+        unsafe fn ref_from_abi(js: Self::Abi) -> Self::Anchor {
+            SelfOwner(Self::from_abi(js))
         }
     }
 };

--- a/tests/expand/generic_enum.expanded.rs
+++ b/tests/expand/generic_enum.expanded.rs
@@ -11,7 +11,10 @@ const _: () = {
     extern crate serde as _serde;
     use tsify::Tsify;
     use wasm_bindgen::{
-        convert::{FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi, OptionIntoWasmAbi},
+        convert::{
+            FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi, OptionIntoWasmAbi,
+            RefFromWasmAbi,
+        },
         describe::WasmDescribe, prelude::*,
     };
     #[wasm_bindgen]
@@ -71,6 +74,23 @@ const _: () = {
         #[inline]
         fn is_none(js: &Self::Abi) -> bool {
             <JsType as OptionFromWasmAbi>::is_none(js)
+        }
+    }
+    pub struct SelfOwner<T>(T);
+    impl<T> ::core::ops::Deref for SelfOwner<T> {
+        type Target = T;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+    impl<T, U> RefFromWasmAbi for GenericEnum<T, U>
+    where
+        Self: _serde::de::DeserializeOwned,
+    {
+        type Abi = <JsType as RefFromWasmAbi>::Abi;
+        type Anchor = SelfOwner<Self>;
+        unsafe fn ref_from_abi(js: Self::Abi) -> Self::Anchor {
+            SelfOwner(Self::from_abi(js))
         }
     }
 };

--- a/tests/expand/generic_struct.expanded.rs
+++ b/tests/expand/generic_struct.expanded.rs
@@ -8,7 +8,10 @@ const _: () = {
     extern crate serde as _serde;
     use tsify::Tsify;
     use wasm_bindgen::{
-        convert::{FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi, OptionIntoWasmAbi},
+        convert::{
+            FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi, OptionIntoWasmAbi,
+            RefFromWasmAbi,
+        },
         describe::WasmDescribe, prelude::*,
     };
     #[wasm_bindgen]
@@ -70,6 +73,23 @@ const _: () = {
             <JsType as OptionFromWasmAbi>::is_none(js)
         }
     }
+    pub struct SelfOwner<T>(T);
+    impl<T> ::core::ops::Deref for SelfOwner<T> {
+        type Target = T;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+    impl<T> RefFromWasmAbi for GenericStruct<T>
+    where
+        Self: _serde::de::DeserializeOwned,
+    {
+        type Abi = <JsType as RefFromWasmAbi>::Abi;
+        type Anchor = SelfOwner<Self>;
+        unsafe fn ref_from_abi(js: Self::Abi) -> Self::Anchor {
+            SelfOwner(Self::from_abi(js))
+        }
+    }
 };
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub struct GenericNewtype<T>(T);
@@ -78,7 +98,10 @@ const _: () = {
     extern crate serde as _serde;
     use tsify::Tsify;
     use wasm_bindgen::{
-        convert::{FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi, OptionIntoWasmAbi},
+        convert::{
+            FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi, OptionIntoWasmAbi,
+            RefFromWasmAbi,
+        },
         describe::WasmDescribe, prelude::*,
     };
     #[wasm_bindgen]
@@ -138,6 +161,23 @@ const _: () = {
         #[inline]
         fn is_none(js: &Self::Abi) -> bool {
             <JsType as OptionFromWasmAbi>::is_none(js)
+        }
+    }
+    pub struct SelfOwner<T>(T);
+    impl<T> ::core::ops::Deref for SelfOwner<T> {
+        type Target = T;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+    impl<T> RefFromWasmAbi for GenericNewtype<T>
+    where
+        Self: _serde::de::DeserializeOwned,
+    {
+        type Abi = <JsType as RefFromWasmAbi>::Abi;
+        type Anchor = SelfOwner<Self>;
+        unsafe fn ref_from_abi(js: Self::Abi) -> Self::Anchor {
+            SelfOwner(Self::from_abi(js))
         }
     }
 };


### PR DESCRIPTION
Closes https://github.com/madonoharu/tsify/issues/3

I only implemented support for & as I thought &mut would give the impression that you could actually modify the object when in reality you are looking at a just-reffed value.

Support for this comes up in practice when you want a function that works for both rust types and on the wasm boundary (comes up in testing a ton).

I'm going to test this with my project first before this should get merged.