### PR TITLE
update serde_derive_internal and test rename_all_fields

### DIFF
--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -228,6 +228,22 @@ fn test_untagged_enum_with_namespace() {
 }
 
 #[test]
+fn test_renamed_enum() {
+    #[derive(Tsify)]
+    #[serde(rename_all_fields = "camelCase")]
+    enum Renamed {
+        First { foo_bar: String, baz_quoox: i32 },
+        Second { asdf_asdf: String, qwer_qwer: i32 },
+    }
+
+    let expected = indoc! {r#"
+        export type Renamed = { First: { fooBar: string; bazQuoox: number } } | { Second: { asdfAsdf: string; qwerQwer: number } };"#
+    };
+
+    assert_eq!(Renamed::DECL, expected);
+}
+
+#[test]
 fn test_module_reimport_enum() {
     #[derive(Tsify)]
     #[tsify(namespace)]

--- a/tsify-macros/Cargo.toml
+++ b/tsify-macros/Cargo.toml
@@ -16,8 +16,13 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "2.0", default-features = false, features = ["full", "parsing", "printing", "proc-macro"] }
-serde_derive_internals = "0.28"
+syn = { version = "2.0", default-features = false, features = [
+    "full",
+    "parsing",
+    "printing",
+    "proc-macro",
+] }
+serde_derive_internals = "0.29"
 
 [features]
 wasm-bindgen = []

--- a/tsify-macros/src/container.rs
+++ b/tsify-macros/src/container.rs
@@ -57,7 +57,7 @@ impl<'a> Container<'a> {
     }
 
     pub fn name(&self) -> String {
-        self.serde_attrs().name().serialize_name()
+        self.serde_attrs().name().serialize_name().to_owned()
     }
 
     pub fn generics(&self) -> &syn::Generics {

--- a/tsify-macros/src/parser.rs
+++ b/tsify-macros/src/parser.rs
@@ -208,7 +208,7 @@ impl<'a> Parser<'a> {
         let members = members
             .into_iter()
             .map(|field| {
-                let key = field.attrs.name().serialize_name();
+                let key = field.attrs.name().serialize_name().to_owned();
                 let (type_ann, field_attrs) = self.parse_field(field);
 
                 let optional = field_attrs.map_or(false, |attrs| attrs.optional);
@@ -247,7 +247,7 @@ impl<'a> Parser<'a> {
             .map(|variant| {
                 let decl = self.create_type_alias_decl(self.parse_variant(variant));
                 if let Decl::TsTypeAlias(mut type_alias) = decl {
-                    type_alias.id = variant.attrs.name().serialize_name();
+                    type_alias.id = variant.attrs.name().serialize_name().to_owned();
 
                     type_alias
                 } else {
@@ -273,7 +273,7 @@ impl<'a> Parser<'a> {
 
     fn parse_variant(&self, variant: &Variant) -> TsType {
         let tag_type = self.container.serde_attrs().tag();
-        let name = variant.attrs.name().serialize_name();
+        let name = variant.attrs.name().serialize_name().to_owned();
         let style = variant.style;
         let type_ann: TsType = self.parse_fields(style, &variant.fields).into();
         type_ann.with_tag_type(name, style, tag_type)


### PR DESCRIPTION
rename_all_fields was added in 0.29, so this is required for tsify users to use the new feature.