### PR TITLE
Bump serde_wasm_bindgen and gloo-utils dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ tsify-macros = { path = "tsify-macros", version = "0.4.3" }
 wasm-bindgen = { version = "0.2.86", optional = true }
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
-serde-wasm-bindgen = { version = "0.5.0", optional = true }
-gloo-utils = { version = "0.1.6", optional = true }
+serde-wasm-bindgen = { version = "0.6.3", optional = true }
+gloo-utils = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 indoc = "2.0.1"
@@ -24,7 +24,7 @@ js-sys = "0.3.63"
 macrotest = "1.0"
 pretty_assertions = "1.3.0"
 serde = { version = "1.0", features = ["derive"] }
-serde-wasm-bindgen = "0.5.0"
+serde-wasm-bindgen = "0.6.3"
 serde_json = "1.0"
 wasm-bindgen = "0.2.86"
 wasm-bindgen-test = "0.3.36"


### PR DESCRIPTION
This just bumps some dependencies up to the latest versions.