### PR TITLE
feat: `impl From<T> for JsValue where T: IntoWasmAbi + Tsify`

### DIFF
--- a/tests/expand/borrow.expanded.rs
+++ b/tests/expand/borrow.expanded.rs
@@ -204,6 +204,12 @@ const _: () = {
             <JsType as OptionIntoWasmAbi>::none()
         }
     }
+    impl<'a> From<Borrow<'a>> for JsValue {
+        #[inline]
+        fn from(value: Borrow<'a>) -> Self {
+            value.into_js().unwrap_throw().into()
+        }
+    }
     impl<'a> FromWasmAbi for Borrow<'a>
     where
         Self: _serde::de::DeserializeOwned,

--- a/tests/expand/generic_enum.expanded.rs
+++ b/tests/expand/generic_enum.expanded.rs
@@ -210,6 +210,12 @@ const _: () = {
             <JsType as OptionIntoWasmAbi>::none()
         }
     }
+    impl<T, U> From<GenericEnum<T, U>> for JsValue {
+        #[inline]
+        fn from(value: GenericEnum<T, U>) -> Self {
+            value.into_js().unwrap_throw().into()
+        }
+    }
     impl<T, U> FromWasmAbi for GenericEnum<T, U>
     where
         Self: _serde::de::DeserializeOwned,

--- a/tests/expand/generic_struct.expanded.rs
+++ b/tests/expand/generic_struct.expanded.rs
@@ -209,6 +209,12 @@ const _: () = {
             <JsType as OptionIntoWasmAbi>::none()
         }
     }
+    impl<T> From<GenericStruct<T>> for JsValue {
+        #[inline]
+        fn from(value: GenericStruct<T>) -> Self {
+            value.into_js().unwrap_throw().into()
+        }
+    }
     impl<T> FromWasmAbi for GenericStruct<T>
     where
         Self: _serde::de::DeserializeOwned,
@@ -457,6 +463,12 @@ const _: () = {
         #[inline]
         fn none() -> Self::Abi {
             <JsType as OptionIntoWasmAbi>::none()
+        }
+    }
+    impl<T> From<GenericNewtype<T>> for JsValue {
+        #[inline]
+        fn from(value: GenericNewtype<T>) -> Self {
+            value.into_js().unwrap_throw().into()
         }
     }
     impl<T> FromWasmAbi for GenericNewtype<T>

--- a/tsify-next-macros/src/wasm_bindgen.rs
+++ b/tsify-next-macros/src/wasm_bindgen.rs
@@ -110,6 +110,13 @@ fn expand_into_wasm_abi(cont: &Container) -> TokenStream {
                 <JsType as OptionIntoWasmAbi>::none()
             }
         }
+
+        impl #impl_generics From<#ident #ty_generics> for JsValue {
+            #[inline]
+            fn from(value: #ident #ty_generics) -> Self {
+                value.into_js().unwrap_throw().into()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fix: #21 

The main motivation of this PR is to allows `Result<T, E>` to implement hidden trait `IntoJsResult` which is required for a returned value to be allowed in `async` function exported by `wasm-bindgen`.