### PR TITLE
Fix #25

### DIFF
--- a/tests-e2e/test3/Cargo.toml
+++ b/tests-e2e/test3/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "test3"
+publish = false
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+wasm-bindgen = "0.2"
+tsify-next = { path = "../..", version = "*" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+
+[lib]
+path = "entry_point.rs"
+crate-type = ["cdylib"]
+
+[build-dependencies]
+wasm-bindgen-cli = "0.2"

--- a/tests-e2e/test3/entry_point.rs
+++ b/tests-e2e/test3/entry_point.rs
@@ -1,0 +1,10 @@
+use serde::Serialize;
+use tsify_next::Tsify;
+use wasm_bindgen::prelude::*;
+
+#[derive(Serialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct Identified<Id, Value> {
+    pub id: Id,
+    pub value: Value,
+}

--- a/tests/expand/borrow.expanded.rs
+++ b/tests/expand/borrow.expanded.rs
@@ -204,7 +204,10 @@ const _: () = {
             <JsType as OptionIntoWasmAbi>::none()
         }
     }
-    impl<'a> From<Borrow<'a>> for JsValue {
+    impl<'a> From<Borrow<'a>> for JsValue
+    where
+        Borrow<'a>: _serde::Serialize,
+    {
         #[inline]
         fn from(value: Borrow<'a>) -> Self {
             value.into_js().unwrap_throw().into()

--- a/tests/expand/generic_enum.expanded.rs
+++ b/tests/expand/generic_enum.expanded.rs
@@ -210,7 +210,10 @@ const _: () = {
             <JsType as OptionIntoWasmAbi>::none()
         }
     }
-    impl<T, U> From<GenericEnum<T, U>> for JsValue {
+    impl<T, U> From<GenericEnum<T, U>> for JsValue
+    where
+        GenericEnum<T, U>: _serde::Serialize,
+    {
         #[inline]
         fn from(value: GenericEnum<T, U>) -> Self {
             value.into_js().unwrap_throw().into()

--- a/tests/expand/generic_struct.expanded.rs
+++ b/tests/expand/generic_struct.expanded.rs
@@ -209,7 +209,10 @@ const _: () = {
             <JsType as OptionIntoWasmAbi>::none()
         }
     }
-    impl<T> From<GenericStruct<T>> for JsValue {
+    impl<T> From<GenericStruct<T>> for JsValue
+    where
+        GenericStruct<T>: _serde::Serialize,
+    {
         #[inline]
         fn from(value: GenericStruct<T>) -> Self {
             value.into_js().unwrap_throw().into()
@@ -465,7 +468,10 @@ const _: () = {
             <JsType as OptionIntoWasmAbi>::none()
         }
     }
-    impl<T> From<GenericNewtype<T>> for JsValue {
+    impl<T> From<GenericNewtype<T>> for JsValue
+    where
+        GenericNewtype<T>: _serde::Serialize,
+    {
         #[inline]
         fn from(value: GenericNewtype<T>) -> Self {
             value.into_js().unwrap_throw().into()

--- a/tsify-next-macros/src/wasm_bindgen.rs
+++ b/tsify-next-macros/src/wasm_bindgen.rs
@@ -94,7 +94,10 @@ fn expand_into_wasm_abi(cont: &Container) -> TokenStream {
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
-    let serde_where_clause = WhereClause { where_token: parse_quote!(where), predicates: parse_quote!(#ident #ty_generics: #serde_path::Serialize)};
+    let serde_where_clause = WhereClause {
+        where_token: parse_quote!(where),
+        predicates: parse_quote!(#ident #ty_generics: #serde_path::Serialize),
+    };
 
     quote! {
         impl #impl_generics IntoWasmAbi for #ident #ty_generics #where_clause {

--- a/tsify-next-macros/src/wasm_bindgen.rs
+++ b/tsify-next-macros/src/wasm_bindgen.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::parse_quote;
+use syn::{parse_quote, WhereClause};
 
 use crate::{container::Container, decl::Decl};
 
@@ -94,6 +94,8 @@ fn expand_into_wasm_abi(cont: &Container) -> TokenStream {
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
+    let serde_where_clause = WhereClause { where_token: parse_quote!(where), predicates: parse_quote!(#ident #ty_generics: #serde_path::Serialize)};
+
     quote! {
         impl #impl_generics IntoWasmAbi for #ident #ty_generics #where_clause {
             type Abi = <JsType as IntoWasmAbi>::Abi;
@@ -111,7 +113,7 @@ fn expand_into_wasm_abi(cont: &Container) -> TokenStream {
             }
         }
 
-        impl #impl_generics From<#ident #ty_generics> for JsValue {
+        impl #impl_generics From<#ident #ty_generics> for JsValue #serde_where_clause {
             #[inline]
             fn from(value: #ident #ty_generics) -> Self {
                 value.into_js().unwrap_throw().into()


### PR DESCRIPTION
Fix #25 which is a regression introduced by #22

A where clause was missing when implementing `From<T> for JsValue` in #22

I had to craft it since the `#where_clause` used in `expand_into_wasm_abi` is on `Self` which could only work for the `Into<JsValue>` trait implementation.

I still get an annoying warning `field comments is never read` when compiling but I am not sure if this comes from PR #22 