### PR TITLE
fix: include trait bounds in where clause of From<JsValue>

### DIFF
--- a/tests-e2e/test3/entry_point.rs
+++ b/tests-e2e/test3/entry_point.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::prelude::*;
 
 #[derive(Serialize, Tsify)]
 #[tsify(into_wasm_abi)]
-pub struct Identified<Id, Value> {
+pub struct Identified<Id, Value> where Id: Sync, Value: 'static {
     pub id: Id,
     pub value: Value,
 }

--- a/tests-e2e/test3/entry_point.rs
+++ b/tests-e2e/test3/entry_point.rs
@@ -4,7 +4,11 @@ use wasm_bindgen::prelude::*;
 
 #[derive(Serialize, Tsify)]
 #[tsify(into_wasm_abi)]
-pub struct Identified<Id, Value> where Id: Sync, Value: 'static {
+pub struct Identified<Id, Value>
+where
+    Id: Sync,
+    Value: 'static,
+{
     pub id: Id,
     pub value: Value,
 }

--- a/tests/expand/borrow.expanded.rs
+++ b/tests/expand/borrow.expanded.rs
@@ -187,7 +187,7 @@ const _: () = {
     }
     impl<'a> IntoWasmAbi for Borrow<'a>
     where
-        Self: _serde::Serialize,
+        Borrow<'a>: _serde::Serialize,
     {
         type Abi = <JsType as IntoWasmAbi>::Abi;
         #[inline]
@@ -197,7 +197,7 @@ const _: () = {
     }
     impl<'a> OptionIntoWasmAbi for Borrow<'a>
     where
-        Self: _serde::Serialize,
+        Borrow<'a>: _serde::Serialize,
     {
         #[inline]
         fn none() -> Self::Abi {

--- a/tests/expand/generic_enum.expanded.rs
+++ b/tests/expand/generic_enum.expanded.rs
@@ -193,7 +193,7 @@ const _: () = {
     }
     impl<T, U> IntoWasmAbi for GenericEnum<T, U>
     where
-        Self: _serde::Serialize,
+        GenericEnum<T, U>: _serde::Serialize,
     {
         type Abi = <JsType as IntoWasmAbi>::Abi;
         #[inline]
@@ -203,7 +203,7 @@ const _: () = {
     }
     impl<T, U> OptionIntoWasmAbi for GenericEnum<T, U>
     where
-        Self: _serde::Serialize,
+        GenericEnum<T, U>: _serde::Serialize,
     {
         #[inline]
         fn none() -> Self::Abi {

--- a/tests/expand/generic_struct.expanded.rs
+++ b/tests/expand/generic_struct.expanded.rs
@@ -192,7 +192,7 @@ const _: () = {
     }
     impl<T> IntoWasmAbi for GenericStruct<T>
     where
-        Self: _serde::Serialize,
+        GenericStruct<T>: _serde::Serialize,
     {
         type Abi = <JsType as IntoWasmAbi>::Abi;
         #[inline]
@@ -202,7 +202,7 @@ const _: () = {
     }
     impl<T> OptionIntoWasmAbi for GenericStruct<T>
     where
-        Self: _serde::Serialize,
+        GenericStruct<T>: _serde::Serialize,
     {
         #[inline]
         fn none() -> Self::Abi {
@@ -451,7 +451,7 @@ const _: () = {
     }
     impl<T> IntoWasmAbi for GenericNewtype<T>
     where
-        Self: _serde::Serialize,
+        GenericNewtype<T>: _serde::Serialize,
     {
         type Abi = <JsType as IntoWasmAbi>::Abi;
         #[inline]
@@ -461,7 +461,7 @@ const _: () = {
     }
     impl<T> OptionIntoWasmAbi for GenericNewtype<T>
     where
-        Self: _serde::Serialize,
+        GenericNewtype<T>: _serde::Serialize,
     {
         #[inline]
         fn none() -> Self::Abi {

--- a/tsify-next-macros/src/wasm_bindgen.rs
+++ b/tsify-next-macros/src/wasm_bindgen.rs
@@ -86,15 +86,14 @@ fn expand_into_wasm_abi(cont: &Container) -> TokenStream {
     let ident = cont.ident();
     let serde_path = cont.serde_container.attrs.serde_path();
 
+    let borrowed_generics = cont.generics();
     let mut generics = cont.generics().clone();
-    generics.make_where_clause();
+    generics
+        .make_where_clause()
+        .predicates
+        .push(parse_quote!(#ident #borrowed_generics: #serde_path::Serialize));
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-
-    let mut where_clause = where_clause.unwrap().clone();
-    where_clause
-        .predicates
-        .push(parse_quote!(#ident #ty_generics: #serde_path::Serialize));
 
     quote! {
         impl #impl_generics IntoWasmAbi for #ident #ty_generics #where_clause {

--- a/tsify-next-macros/src/wasm_bindgen.rs
+++ b/tsify-next-macros/src/wasm_bindgen.rs
@@ -87,13 +87,14 @@ fn expand_into_wasm_abi(cont: &Container) -> TokenStream {
     let serde_path = cont.serde_container.attrs.serde_path();
 
     let mut generics = cont.generics().clone();
-    generics
-        .make_where_clause();
+    generics.make_where_clause();
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     let mut where_clause = where_clause.unwrap().clone();
-    where_clause.predicates.push(parse_quote!(#ident #ty_generics: #serde_path::Serialize));
+    where_clause
+        .predicates
+        .push(parse_quote!(#ident #ty_generics: #serde_path::Serialize));
 
     quote! {
         impl #impl_generics IntoWasmAbi for #ident #ty_generics #where_clause {


### PR DESCRIPTION
This should once and for all (I hope 😅) fix #25 
I also updated the e2e test to catch the case of trait bounds (and even lifetime constraint)

However I am not very satisfied by this fix because it actually replaces `Self` in where clause with the type on which we are implementing `IntoWasmAbi` and `From<JsValue>`which I think is a bit hacky and maybe not how the `syn::Generics` interface is intended to be used.

A "more `syn` friendly interface" could be to not implement `From<JsValue>` but `Into` directly and use `Self` as usual, this will however require to disable a clippy warning.

So every solution I think of are meh, one thing for sure: we really need those e2e tests with more case coverage 😬 

Let me know if you have a better idea to fix this @siefkenj @nappa85