### PR TITLE
feat: impl LongRefFromWasmAbi for T where T: Tsify + FromWasmAbi

### DIFF
--- a/tests/expand/borrow.expanded.rs
+++ b/tests/expand/borrow.expanded.rs
@@ -12,7 +12,7 @@ const _: () = {
     use wasm_bindgen::{
         convert::{
             FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi, OptionIntoWasmAbi,
-            RefFromWasmAbi,
+            RefFromWasmAbi, LongRefFromWasmAbi,
         },
         describe::WasmDescribe, prelude::*,
     };
@@ -243,6 +243,11 @@ const _: () = {
             &self.0
         }
     }
+    impl<T> ::core::borrow::Borrow<T> for SelfOwner<T> {
+        fn borrow(&self) -> &T {
+            &self.0
+        }
+    }
     impl<'a> RefFromWasmAbi for Borrow<'a>
     where
         Self: _serde::de::DeserializeOwned,
@@ -251,6 +256,20 @@ const _: () = {
         type Anchor = SelfOwner<Self>;
         unsafe fn ref_from_abi(js: Self::Abi) -> Self::Anchor {
             let result = Self::from_js(&*JsType::ref_from_abi(js));
+            if let Err(err) = result {
+                wasm_bindgen::throw_str(err.to_string().as_ref());
+            }
+            SelfOwner(result.unwrap_throw())
+        }
+    }
+    impl<'a> LongRefFromWasmAbi for Borrow<'a>
+    where
+        Self: _serde::de::DeserializeOwned,
+    {
+        type Abi = <JsType as LongRefFromWasmAbi>::Abi;
+        type Anchor = SelfOwner<Self>;
+        unsafe fn long_ref_from_abi(js: Self::Abi) -> Self::Anchor {
+            let result = Self::from_js(&JsType::from_abi(js));
             if let Err(err) = result {
                 wasm_bindgen::throw_str(err.to_string().as_ref());
             }

--- a/tests/expand/generic_struct.expanded.rs
+++ b/tests/expand/generic_struct.expanded.rs
@@ -10,7 +10,7 @@ const _: () = {
     use wasm_bindgen::{
         convert::{
             FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi, OptionIntoWasmAbi,
-            RefFromWasmAbi,
+            RefFromWasmAbi, LongRefFromWasmAbi,
         },
         describe::WasmDescribe, prelude::*,
     };
@@ -248,6 +248,11 @@ const _: () = {
             &self.0
         }
     }
+    impl<T> ::core::borrow::Borrow<T> for SelfOwner<T> {
+        fn borrow(&self) -> &T {
+            &self.0
+        }
+    }
     impl<T> RefFromWasmAbi for GenericStruct<T>
     where
         Self: _serde::de::DeserializeOwned,
@@ -256,6 +261,20 @@ const _: () = {
         type Anchor = SelfOwner<Self>;
         unsafe fn ref_from_abi(js: Self::Abi) -> Self::Anchor {
             let result = Self::from_js(&*JsType::ref_from_abi(js));
+            if let Err(err) = result {
+                wasm_bindgen::throw_str(err.to_string().as_ref());
+            }
+            SelfOwner(result.unwrap_throw())
+        }
+    }
+    impl<T> LongRefFromWasmAbi for GenericStruct<T>
+    where
+        Self: _serde::de::DeserializeOwned,
+    {
+        type Abi = <JsType as LongRefFromWasmAbi>::Abi;
+        type Anchor = SelfOwner<Self>;
+        unsafe fn long_ref_from_abi(js: Self::Abi) -> Self::Anchor {
+            let result = Self::from_js(&JsType::from_abi(js));
             if let Err(err) = result {
                 wasm_bindgen::throw_str(err.to_string().as_ref());
             }
@@ -272,7 +291,7 @@ const _: () = {
     use wasm_bindgen::{
         convert::{
             FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi, OptionIntoWasmAbi,
-            RefFromWasmAbi,
+            RefFromWasmAbi, LongRefFromWasmAbi,
         },
         describe::WasmDescribe, prelude::*,
     };
@@ -511,6 +530,11 @@ const _: () = {
             &self.0
         }
     }
+    impl<T> ::core::borrow::Borrow<T> for SelfOwner<T> {
+        fn borrow(&self) -> &T {
+            &self.0
+        }
+    }
     impl<T> RefFromWasmAbi for GenericNewtype<T>
     where
         Self: _serde::de::DeserializeOwned,
@@ -519,6 +543,20 @@ const _: () = {
         type Anchor = SelfOwner<Self>;
         unsafe fn ref_from_abi(js: Self::Abi) -> Self::Anchor {
             let result = Self::from_js(&*JsType::ref_from_abi(js));
+            if let Err(err) = result {
+                wasm_bindgen::throw_str(err.to_string().as_ref());
+            }
+            SelfOwner(result.unwrap_throw())
+        }
+    }
+    impl<T> LongRefFromWasmAbi for GenericNewtype<T>
+    where
+        Self: _serde::de::DeserializeOwned,
+    {
+        type Abi = <JsType as LongRefFromWasmAbi>::Abi;
+        type Anchor = SelfOwner<Self>;
+        unsafe fn long_ref_from_abi(js: Self::Abi) -> Self::Anchor {
+            let result = Self::from_js(&JsType::from_abi(js));
             if let Err(err) = result {
                 wasm_bindgen::throw_str(err.to_string().as_ref());
             }


### PR DESCRIPTION
Implement #34

I tried to make a test of the behavior by building a test very similar to #33 using async function for `validate` and it fails 😧... 

which is expected because Rust must be responsible for dropping the reference to the closure here so you cannot invoke the closure twice and we have no way to check it in Rust according to rustwasm/wasm-bindgen#3178 so this suggest my implementation is right actually 😃  ... 

But it also fails if I use the same implementation as `RefFromWasmAbi` for the `LongRefFromWasmAbi` 😧, which normally does not drop the reference at the end of the first Rust invocation and so allow the second invocation to be processed.

In summary, I am not sure how to test that my implementation is the correct one 😕

I leave this PR here for people who are maybe more knowledgeable building a test for this. My main issue is that we cannot take an async closure as function argument to reproduce a test like in aaaa3982d2e0a5959acd162d10cb0ef6105ea9fa where `validation` is `async`