### PR TITLE
Forward error messages when converting to js types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # tsify-next Changelog
 
+## v0.5.3
+
+-   Propagate errors encountered during serialization.
+-   More fixes for missing `From` trait implementations.
+
 ## v0.5.2
 
 -   Fix missing trait bounds for implemented `From` traits.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsify-next"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 authors = [
   "Madono Haru <madonoharu@gmail.com>",
@@ -14,7 +14,7 @@ keywords = ["wasm", "wasm-bindgen", "typescript"]
 categories = ["wasm"]
 
 [dependencies]
-tsify-next-macros = { path = "tsify-next-macros", version = "0.5.2" }
+tsify-next-macros = { path = "tsify-next-macros", version = "0.5.3" }
 wasm-bindgen = { version = "0.2.86", optional = true }
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Click to show Cargo.toml.
 
 ```toml
 [dependencies]
-tsify-next = "0.5.2"
+tsify-next = "0.5.3"
 serde = { version = "1.0", features = ["derive"] }
 wasm-bindgen = { version = "0.2" }
 ```

--- a/tests/expand/borrow.expanded.rs
+++ b/tests/expand/borrow.expanded.rs
@@ -192,7 +192,34 @@ const _: () = {
         type Abi = <JsType as IntoWasmAbi>::Abi;
         #[inline]
         fn into_abi(self) -> Self::Abi {
-            self.into_js().unwrap_throw().into_abi()
+            match self.into_js() {
+                Ok(js) => js.into_abi(),
+                Err(err) => {
+                    let loc = core::panic::Location::caller();
+                    let msg = {
+                        let res = ::alloc::fmt::format(
+                            format_args!(
+                                "(Converting type failed) {0} ({1}:{2}:{3})", err, loc
+                                .file(), loc.line(), loc.column(),
+                            ),
+                        );
+                        res
+                    };
+                    {
+                        #[cold]
+                        #[track_caller]
+                        #[inline(never)]
+                        #[rustc_const_panic_str]
+                        #[rustc_do_not_const_check]
+                        const fn panic_cold_display<T: ::core::fmt::Display>(
+                            arg: &T,
+                        ) -> ! {
+                            ::core::panicking::panic_display(arg)
+                        }
+                        panic_cold_display(&msg);
+                    };
+                }
+            }
         }
     }
     impl<'a> OptionIntoWasmAbi for Borrow<'a>
@@ -210,7 +237,34 @@ const _: () = {
     {
         #[inline]
         fn from(value: Borrow<'a>) -> Self {
-            value.into_js().unwrap_throw().into()
+            match value.into_js() {
+                Ok(js) => js.into(),
+                Err(err) => {
+                    let loc = core::panic::Location::caller();
+                    let msg = {
+                        let res = ::alloc::fmt::format(
+                            format_args!(
+                                "(Converting type failed) {0} ({1}:{2}:{3})", err, loc
+                                .file(), loc.line(), loc.column(),
+                            ),
+                        );
+                        res
+                    };
+                    {
+                        #[cold]
+                        #[track_caller]
+                        #[inline(never)]
+                        #[rustc_const_panic_str]
+                        #[rustc_do_not_const_check]
+                        const fn panic_cold_display<T: ::core::fmt::Display>(
+                            arg: &T,
+                        ) -> ! {
+                            ::core::panicking::panic_display(arg)
+                        }
+                        panic_cold_display(&msg);
+                    };
+                }
+            }
         }
     }
     impl<'a> FromWasmAbi for Borrow<'a>

--- a/tests/expand/generic_enum.expanded.rs
+++ b/tests/expand/generic_enum.expanded.rs
@@ -198,7 +198,34 @@ const _: () = {
         type Abi = <JsType as IntoWasmAbi>::Abi;
         #[inline]
         fn into_abi(self) -> Self::Abi {
-            self.into_js().unwrap_throw().into_abi()
+            match self.into_js() {
+                Ok(js) => js.into_abi(),
+                Err(err) => {
+                    let loc = core::panic::Location::caller();
+                    let msg = {
+                        let res = ::alloc::fmt::format(
+                            format_args!(
+                                "(Converting type failed) {0} ({1}:{2}:{3})", err, loc
+                                .file(), loc.line(), loc.column(),
+                            ),
+                        );
+                        res
+                    };
+                    {
+                        #[cold]
+                        #[track_caller]
+                        #[inline(never)]
+                        #[rustc_const_panic_str]
+                        #[rustc_do_not_const_check]
+                        const fn panic_cold_display<T: ::core::fmt::Display>(
+                            arg: &T,
+                        ) -> ! {
+                            ::core::panicking::panic_display(arg)
+                        }
+                        panic_cold_display(&msg);
+                    };
+                }
+            }
         }
     }
     impl<T, U> OptionIntoWasmAbi for GenericEnum<T, U>
@@ -216,7 +243,34 @@ const _: () = {
     {
         #[inline]
         fn from(value: GenericEnum<T, U>) -> Self {
-            value.into_js().unwrap_throw().into()
+            match value.into_js() {
+                Ok(js) => js.into(),
+                Err(err) => {
+                    let loc = core::panic::Location::caller();
+                    let msg = {
+                        let res = ::alloc::fmt::format(
+                            format_args!(
+                                "(Converting type failed) {0} ({1}:{2}:{3})", err, loc
+                                .file(), loc.line(), loc.column(),
+                            ),
+                        );
+                        res
+                    };
+                    {
+                        #[cold]
+                        #[track_caller]
+                        #[inline(never)]
+                        #[rustc_const_panic_str]
+                        #[rustc_do_not_const_check]
+                        const fn panic_cold_display<T: ::core::fmt::Display>(
+                            arg: &T,
+                        ) -> ! {
+                            ::core::panicking::panic_display(arg)
+                        }
+                        panic_cold_display(&msg);
+                    };
+                }
+            }
         }
     }
     impl<T, U> FromWasmAbi for GenericEnum<T, U>

--- a/tests/expand/generic_struct.expanded.rs
+++ b/tests/expand/generic_struct.expanded.rs
@@ -197,7 +197,34 @@ const _: () = {
         type Abi = <JsType as IntoWasmAbi>::Abi;
         #[inline]
         fn into_abi(self) -> Self::Abi {
-            self.into_js().unwrap_throw().into_abi()
+            match self.into_js() {
+                Ok(js) => js.into_abi(),
+                Err(err) => {
+                    let loc = core::panic::Location::caller();
+                    let msg = {
+                        let res = ::alloc::fmt::format(
+                            format_args!(
+                                "(Converting type failed) {0} ({1}:{2}:{3})", err, loc
+                                .file(), loc.line(), loc.column(),
+                            ),
+                        );
+                        res
+                    };
+                    {
+                        #[cold]
+                        #[track_caller]
+                        #[inline(never)]
+                        #[rustc_const_panic_str]
+                        #[rustc_do_not_const_check]
+                        const fn panic_cold_display<T: ::core::fmt::Display>(
+                            arg: &T,
+                        ) -> ! {
+                            ::core::panicking::panic_display(arg)
+                        }
+                        panic_cold_display(&msg);
+                    };
+                }
+            }
         }
     }
     impl<T> OptionIntoWasmAbi for GenericStruct<T>
@@ -215,7 +242,34 @@ const _: () = {
     {
         #[inline]
         fn from(value: GenericStruct<T>) -> Self {
-            value.into_js().unwrap_throw().into()
+            match value.into_js() {
+                Ok(js) => js.into(),
+                Err(err) => {
+                    let loc = core::panic::Location::caller();
+                    let msg = {
+                        let res = ::alloc::fmt::format(
+                            format_args!(
+                                "(Converting type failed) {0} ({1}:{2}:{3})", err, loc
+                                .file(), loc.line(), loc.column(),
+                            ),
+                        );
+                        res
+                    };
+                    {
+                        #[cold]
+                        #[track_caller]
+                        #[inline(never)]
+                        #[rustc_const_panic_str]
+                        #[rustc_do_not_const_check]
+                        const fn panic_cold_display<T: ::core::fmt::Display>(
+                            arg: &T,
+                        ) -> ! {
+                            ::core::panicking::panic_display(arg)
+                        }
+                        panic_cold_display(&msg);
+                    };
+                }
+            }
         }
     }
     impl<T> FromWasmAbi for GenericStruct<T>
@@ -460,7 +514,34 @@ const _: () = {
         type Abi = <JsType as IntoWasmAbi>::Abi;
         #[inline]
         fn into_abi(self) -> Self::Abi {
-            self.into_js().unwrap_throw().into_abi()
+            match self.into_js() {
+                Ok(js) => js.into_abi(),
+                Err(err) => {
+                    let loc = core::panic::Location::caller();
+                    let msg = {
+                        let res = ::alloc::fmt::format(
+                            format_args!(
+                                "(Converting type failed) {0} ({1}:{2}:{3})", err, loc
+                                .file(), loc.line(), loc.column(),
+                            ),
+                        );
+                        res
+                    };
+                    {
+                        #[cold]
+                        #[track_caller]
+                        #[inline(never)]
+                        #[rustc_const_panic_str]
+                        #[rustc_do_not_const_check]
+                        const fn panic_cold_display<T: ::core::fmt::Display>(
+                            arg: &T,
+                        ) -> ! {
+                            ::core::panicking::panic_display(arg)
+                        }
+                        panic_cold_display(&msg);
+                    };
+                }
+            }
         }
     }
     impl<T> OptionIntoWasmAbi for GenericNewtype<T>
@@ -478,7 +559,34 @@ const _: () = {
     {
         #[inline]
         fn from(value: GenericNewtype<T>) -> Self {
-            value.into_js().unwrap_throw().into()
+            match value.into_js() {
+                Ok(js) => js.into(),
+                Err(err) => {
+                    let loc = core::panic::Location::caller();
+                    let msg = {
+                        let res = ::alloc::fmt::format(
+                            format_args!(
+                                "(Converting type failed) {0} ({1}:{2}:{3})", err, loc
+                                .file(), loc.line(), loc.column(),
+                            ),
+                        );
+                        res
+                    };
+                    {
+                        #[cold]
+                        #[track_caller]
+                        #[inline(never)]
+                        #[rustc_const_panic_str]
+                        #[rustc_do_not_const_check]
+                        const fn panic_cold_display<T: ::core::fmt::Display>(
+                            arg: &T,
+                        ) -> ! {
+                            ::core::panicking::panic_display(arg)
+                        }
+                        panic_cold_display(&msg);
+                    };
+                }
+            }
         }
     }
     impl<T> FromWasmAbi for GenericNewtype<T>

--- a/tests/expandtest.rs
+++ b/tests/expandtest.rs
@@ -1,3 +1,7 @@
+//! Generates expanded code for tests in `tests/expand/` directory.
+//! To update the expected output, run with `MACROTEST=overwrite cargo test`
+//! or delete the `.expanded.rs` files.
+
 #[test]
 fn expandtest() {
     macrotest::expand_args("tests/expand/*.rs", ["--features", "tsify-next/json"]);

--- a/tsify-next-macros/Cargo.toml
+++ b/tsify-next-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsify-next-macros"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 authors = [
     "Madono Haru <madonoharu@gmail.com>",


### PR DESCRIPTION
Due to https://github.com/rustwasm/wasm-bindgen/issues/2732 the use of `wasm_bindgen`'s `unwrap_throw()` does not forward the error message that was encountered during serialization. This makes debugging much harder.

This PR forwards the error message that was encountered.