### PR TITLE
Put #[automatically_derived] on impls

### DIFF
--- a/tests/expand/borrow.expanded.rs
+++ b/tests/expand/borrow.expanded.rs
@@ -5,7 +5,6 @@ struct Borrow<'a> {
     raw: &'a str,
     cow: Cow<'a, str>,
 }
-#[automatically_derived]
 const _: () = {
     extern crate serde as _serde;
     use tsify_next::Tsify;
@@ -21,6 +20,7 @@ const _: () = {
         #[wasm_bindgen(typescript_type = "Borrow")]
         pub type JsType;
     }
+    #[automatically_derived]
     impl<'a> Tsify for Borrow<'a> {
         type JsType = JsType;
         const DECL: &'static str = "export interface Borrow {\n    raw: string;\n    cow: string;\n}";
@@ -32,18 +32,21 @@ const _: () = {
     }
     #[wasm_bindgen(typescript_custom_section)]
     const TS_APPEND_CONTENT: &'static str = "export interface Borrow {\n    raw: string;\n    cow: string;\n}";
+    #[automatically_derived]
     impl<'a> WasmDescribe for Borrow<'a> {
         #[inline]
         fn describe() {
             <Self as Tsify>::JsType::describe()
         }
     }
+    #[automatically_derived]
     impl<'a> WasmDescribeVector for Borrow<'a> {
         #[inline]
         fn describe_vector() {
             <Self as Tsify>::JsType::describe_vector()
         }
     }
+    #[automatically_derived]
     impl<'a> IntoWasmAbi for Borrow<'a>
     where
         Borrow<'a>: _serde::Serialize,
@@ -81,6 +84,7 @@ const _: () = {
             }
         }
     }
+    #[automatically_derived]
     impl<'a> OptionIntoWasmAbi for Borrow<'a>
     where
         Borrow<'a>: _serde::Serialize,
@@ -90,6 +94,7 @@ const _: () = {
             <JsType as OptionIntoWasmAbi>::none()
         }
     }
+    #[automatically_derived]
     impl<'a> From<Borrow<'a>> for JsValue
     where
         Borrow<'a>: _serde::Serialize,
@@ -126,6 +131,7 @@ const _: () = {
             }
         }
     }
+    #[automatically_derived]
     impl<'a> VectorIntoWasmAbi for Borrow<'a>
     where
         Borrow<'a>: _serde::Serialize,
@@ -167,6 +173,7 @@ const _: () = {
             JsValue::vector_into_abi(values)
         }
     }
+    #[automatically_derived]
     impl<'a> FromWasmAbi for Borrow<'a>
     where
         Self: _serde::de::DeserializeOwned,
@@ -181,6 +188,7 @@ const _: () = {
             result.unwrap_throw()
         }
     }
+    #[automatically_derived]
     impl<'a> OptionFromWasmAbi for Borrow<'a>
     where
         Self: _serde::de::DeserializeOwned,
@@ -191,12 +199,14 @@ const _: () = {
         }
     }
     pub struct SelfOwner<T>(T);
+    #[automatically_derived]
     impl<T> ::core::ops::Deref for SelfOwner<T> {
         type Target = T;
         fn deref(&self) -> &Self::Target {
             &self.0
         }
     }
+    #[automatically_derived]
     impl<'a> RefFromWasmAbi for Borrow<'a>
     where
         Self: _serde::de::DeserializeOwned,
@@ -211,6 +221,7 @@ const _: () = {
             SelfOwner(result.unwrap_throw())
         }
     }
+    #[automatically_derived]
     impl<'a> VectorFromWasmAbi for Borrow<'a>
     where
         Self: _serde::de::DeserializeOwned,

--- a/tests/expand/generic_enum.expanded.rs
+++ b/tests/expand/generic_enum.expanded.rs
@@ -6,7 +6,6 @@ pub enum GenericEnum<T, U> {
     Seq(T, U),
     Map { x: T, y: U },
 }
-#[automatically_derived]
 const _: () = {
     extern crate serde as _serde;
     use tsify_next::Tsify;
@@ -22,6 +21,7 @@ const _: () = {
         #[wasm_bindgen(typescript_type = "GenericEnum")]
         pub type JsType;
     }
+    #[automatically_derived]
     impl<T, U> Tsify for GenericEnum<T, U> {
         type JsType = JsType;
         const DECL: &'static str = "export type GenericEnum<T, U> = \"Unit\" | { NewType: T } | { Seq: [T, U] } | { Map: { x: T; y: U } };";
@@ -33,18 +33,21 @@ const _: () = {
     }
     #[wasm_bindgen(typescript_custom_section)]
     const TS_APPEND_CONTENT: &'static str = "export type GenericEnum<T, U> = \"Unit\" | { NewType: T } | { Seq: [T, U] } | { Map: { x: T; y: U } };";
+    #[automatically_derived]
     impl<T, U> WasmDescribe for GenericEnum<T, U> {
         #[inline]
         fn describe() {
             <Self as Tsify>::JsType::describe()
         }
     }
+    #[automatically_derived]
     impl<T, U> WasmDescribeVector for GenericEnum<T, U> {
         #[inline]
         fn describe_vector() {
             <Self as Tsify>::JsType::describe_vector()
         }
     }
+    #[automatically_derived]
     impl<T, U> IntoWasmAbi for GenericEnum<T, U>
     where
         GenericEnum<T, U>: _serde::Serialize,
@@ -82,6 +85,7 @@ const _: () = {
             }
         }
     }
+    #[automatically_derived]
     impl<T, U> OptionIntoWasmAbi for GenericEnum<T, U>
     where
         GenericEnum<T, U>: _serde::Serialize,
@@ -91,6 +95,7 @@ const _: () = {
             <JsType as OptionIntoWasmAbi>::none()
         }
     }
+    #[automatically_derived]
     impl<T, U> From<GenericEnum<T, U>> for JsValue
     where
         GenericEnum<T, U>: _serde::Serialize,
@@ -127,6 +132,7 @@ const _: () = {
             }
         }
     }
+    #[automatically_derived]
     impl<T, U> VectorIntoWasmAbi for GenericEnum<T, U>
     where
         GenericEnum<T, U>: _serde::Serialize,
@@ -168,6 +174,7 @@ const _: () = {
             JsValue::vector_into_abi(values)
         }
     }
+    #[automatically_derived]
     impl<T, U> FromWasmAbi for GenericEnum<T, U>
     where
         Self: _serde::de::DeserializeOwned,
@@ -182,6 +189,7 @@ const _: () = {
             result.unwrap_throw()
         }
     }
+    #[automatically_derived]
     impl<T, U> OptionFromWasmAbi for GenericEnum<T, U>
     where
         Self: _serde::de::DeserializeOwned,
@@ -192,12 +200,14 @@ const _: () = {
         }
     }
     pub struct SelfOwner<T>(T);
+    #[automatically_derived]
     impl<T> ::core::ops::Deref for SelfOwner<T> {
         type Target = T;
         fn deref(&self) -> &Self::Target {
             &self.0
         }
     }
+    #[automatically_derived]
     impl<T, U> RefFromWasmAbi for GenericEnum<T, U>
     where
         Self: _serde::de::DeserializeOwned,
@@ -212,6 +222,7 @@ const _: () = {
             SelfOwner(result.unwrap_throw())
         }
     }
+    #[automatically_derived]
     impl<T, U> VectorFromWasmAbi for GenericEnum<T, U>
     where
         Self: _serde::de::DeserializeOwned,

--- a/tests/expand/generic_struct.expanded.rs
+++ b/tests/expand/generic_struct.expanded.rs
@@ -3,7 +3,6 @@ use tsify_next::Tsify;
 pub struct GenericStruct<T> {
     x: T,
 }
-#[automatically_derived]
 const _: () = {
     extern crate serde as _serde;
     use tsify_next::Tsify;
@@ -19,6 +18,7 @@ const _: () = {
         #[wasm_bindgen(typescript_type = "GenericStruct")]
         pub type JsType;
     }
+    #[automatically_derived]
     impl<T> Tsify for GenericStruct<T> {
         type JsType = JsType;
         const DECL: &'static str = "export interface GenericStruct<T> {\n    x: T;\n}";
@@ -30,18 +30,21 @@ const _: () = {
     }
     #[wasm_bindgen(typescript_custom_section)]
     const TS_APPEND_CONTENT: &'static str = "export interface GenericStruct<T> {\n    x: T;\n}";
+    #[automatically_derived]
     impl<T> WasmDescribe for GenericStruct<T> {
         #[inline]
         fn describe() {
             <Self as Tsify>::JsType::describe()
         }
     }
+    #[automatically_derived]
     impl<T> WasmDescribeVector for GenericStruct<T> {
         #[inline]
         fn describe_vector() {
             <Self as Tsify>::JsType::describe_vector()
         }
     }
+    #[automatically_derived]
     impl<T> IntoWasmAbi for GenericStruct<T>
     where
         GenericStruct<T>: _serde::Serialize,
@@ -79,6 +82,7 @@ const _: () = {
             }
         }
     }
+    #[automatically_derived]
     impl<T> OptionIntoWasmAbi for GenericStruct<T>
     where
         GenericStruct<T>: _serde::Serialize,
@@ -88,6 +92,7 @@ const _: () = {
             <JsType as OptionIntoWasmAbi>::none()
         }
     }
+    #[automatically_derived]
     impl<T> From<GenericStruct<T>> for JsValue
     where
         GenericStruct<T>: _serde::Serialize,
@@ -124,6 +129,7 @@ const _: () = {
             }
         }
     }
+    #[automatically_derived]
     impl<T> VectorIntoWasmAbi for GenericStruct<T>
     where
         GenericStruct<T>: _serde::Serialize,
@@ -165,6 +171,7 @@ const _: () = {
             JsValue::vector_into_abi(values)
         }
     }
+    #[automatically_derived]
     impl<T> FromWasmAbi for GenericStruct<T>
     where
         Self: _serde::de::DeserializeOwned,
@@ -179,6 +186,7 @@ const _: () = {
             result.unwrap_throw()
         }
     }
+    #[automatically_derived]
     impl<T> OptionFromWasmAbi for GenericStruct<T>
     where
         Self: _serde::de::DeserializeOwned,
@@ -189,12 +197,14 @@ const _: () = {
         }
     }
     pub struct SelfOwner<T>(T);
+    #[automatically_derived]
     impl<T> ::core::ops::Deref for SelfOwner<T> {
         type Target = T;
         fn deref(&self) -> &Self::Target {
             &self.0
         }
     }
+    #[automatically_derived]
     impl<T> RefFromWasmAbi for GenericStruct<T>
     where
         Self: _serde::de::DeserializeOwned,
@@ -209,6 +219,7 @@ const _: () = {
             SelfOwner(result.unwrap_throw())
         }
     }
+    #[automatically_derived]
     impl<T> VectorFromWasmAbi for GenericStruct<T>
     where
         Self: _serde::de::DeserializeOwned,
@@ -231,7 +242,6 @@ const _: () = {
 };
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub struct GenericNewtype<T>(T);
-#[automatically_derived]
 const _: () = {
     extern crate serde as _serde;
     use tsify_next::Tsify;
@@ -247,6 +257,7 @@ const _: () = {
         #[wasm_bindgen(typescript_type = "GenericNewtype")]
         pub type JsType;
     }
+    #[automatically_derived]
     impl<T> Tsify for GenericNewtype<T> {
         type JsType = JsType;
         const DECL: &'static str = "export type GenericNewtype<T> = T;";
@@ -258,18 +269,21 @@ const _: () = {
     }
     #[wasm_bindgen(typescript_custom_section)]
     const TS_APPEND_CONTENT: &'static str = "export type GenericNewtype<T> = T;";
+    #[automatically_derived]
     impl<T> WasmDescribe for GenericNewtype<T> {
         #[inline]
         fn describe() {
             <Self as Tsify>::JsType::describe()
         }
     }
+    #[automatically_derived]
     impl<T> WasmDescribeVector for GenericNewtype<T> {
         #[inline]
         fn describe_vector() {
             <Self as Tsify>::JsType::describe_vector()
         }
     }
+    #[automatically_derived]
     impl<T> IntoWasmAbi for GenericNewtype<T>
     where
         GenericNewtype<T>: _serde::Serialize,
@@ -307,6 +321,7 @@ const _: () = {
             }
         }
     }
+    #[automatically_derived]
     impl<T> OptionIntoWasmAbi for GenericNewtype<T>
     where
         GenericNewtype<T>: _serde::Serialize,
@@ -316,6 +331,7 @@ const _: () = {
             <JsType as OptionIntoWasmAbi>::none()
         }
     }
+    #[automatically_derived]
     impl<T> From<GenericNewtype<T>> for JsValue
     where
         GenericNewtype<T>: _serde::Serialize,
@@ -352,6 +368,7 @@ const _: () = {
             }
         }
     }
+    #[automatically_derived]
     impl<T> VectorIntoWasmAbi for GenericNewtype<T>
     where
         GenericNewtype<T>: _serde::Serialize,
@@ -393,6 +410,7 @@ const _: () = {
             JsValue::vector_into_abi(values)
         }
     }
+    #[automatically_derived]
     impl<T> FromWasmAbi for GenericNewtype<T>
     where
         Self: _serde::de::DeserializeOwned,
@@ -407,6 +425,7 @@ const _: () = {
             result.unwrap_throw()
         }
     }
+    #[automatically_derived]
     impl<T> OptionFromWasmAbi for GenericNewtype<T>
     where
         Self: _serde::de::DeserializeOwned,
@@ -417,12 +436,14 @@ const _: () = {
         }
     }
     pub struct SelfOwner<T>(T);
+    #[automatically_derived]
     impl<T> ::core::ops::Deref for SelfOwner<T> {
         type Target = T;
         fn deref(&self) -> &Self::Target {
             &self.0
         }
     }
+    #[automatically_derived]
     impl<T> RefFromWasmAbi for GenericNewtype<T>
     where
         Self: _serde::de::DeserializeOwned,
@@ -437,6 +458,7 @@ const _: () = {
             SelfOwner(result.unwrap_throw())
         }
     }
+    #[automatically_derived]
     impl<T> VectorFromWasmAbi for GenericNewtype<T>
     where
         Self: _serde::de::DeserializeOwned,

--- a/tests/expand/type_alias.expanded.rs
+++ b/tests/expand/type_alias.expanded.rs
@@ -1,5 +1,4 @@
 type TypeAlias<T, U> = Foo<T, i32, U>;
-#[automatically_derived]
 const _: () = {
     use wasm_bindgen::prelude::*;
     #[wasm_bindgen(typescript_custom_section)]

--- a/tsify-next-macros/src/derive.rs
+++ b/tsify-next-macros/src/derive.rs
@@ -19,9 +19,9 @@ pub fn expand(input: DeriveInput) -> syn::Result<TokenStream> {
         wasm_bindgen::expand(&cont, decl)
     } else {
         quote! {
-            #[automatically_derived]
             const _: () = {
                 use tsify_next::Tsify;
+                #[automatically_derived]
                 impl #impl_generics Tsify for #ident #ty_generics #where_clause {
                     const DECL: &'static str = #decl_str;
                     const CONFIG: tsify_next::SerializationConfig;

--- a/tsify-next-macros/src/type_alias.rs
+++ b/tsify-next-macros/src/type_alias.rs
@@ -27,7 +27,6 @@ pub fn expand(item: syn::ItemType) -> syn::Result<TokenStream> {
     let decl_str = decl.to_string();
 
     let typescript_custom_section = quote! {
-        #[automatically_derived]
         const _: () = {
             use wasm_bindgen::prelude::*;
             #[wasm_bindgen(typescript_custom_section)]

--- a/tsify-next-macros/src/wasm_bindgen.rs
+++ b/tsify-next-macros/src/wasm_bindgen.rs
@@ -20,6 +20,7 @@ pub fn expand(cont: &Container, decl: Decl) -> TokenStream {
 
     let wasm_describe = wasm_abi.then(|| {
         quote! {
+            #[automatically_derived]
             impl #impl_generics WasmDescribe for #ident #ty_generics #where_clause {
                 #[inline]
                 fn describe() {
@@ -27,6 +28,7 @@ pub fn expand(cont: &Container, decl: Decl) -> TokenStream {
                 }
             }
 
+            #[automatically_derived]
             impl #impl_generics WasmDescribeVector for #ident #ty_generics #where_clause {
                 #[inline]
                 fn describe_vector() {
@@ -55,7 +57,6 @@ pub fn expand(cont: &Container, decl: Decl) -> TokenStream {
     let large_number_types_as_bigints = attrs.ty_config.large_number_types_as_bigints;
 
     quote! {
-        #[automatically_derived]
         const _: () = {
             #use_serde
             use tsify_next::Tsify;
@@ -72,6 +73,7 @@ pub fn expand(cont: &Container, decl: Decl) -> TokenStream {
                 pub type JsType;
             }
 
+            #[automatically_derived]
             impl #impl_generics Tsify for #ident #ty_generics #where_clause {
                 type JsType = JsType;
                 const DECL: &'static str = #decl_str;
@@ -104,6 +106,7 @@ fn expand_into_wasm_abi(cont: &Container) -> TokenStream {
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     quote! {
+        #[automatically_derived]
         impl #impl_generics IntoWasmAbi for #ident #ty_generics #where_clause {
             type Abi = <JsType as IntoWasmAbi>::Abi;
 
@@ -126,6 +129,7 @@ fn expand_into_wasm_abi(cont: &Container) -> TokenStream {
             }
         }
 
+        #[automatically_derived]
         impl #impl_generics OptionIntoWasmAbi for #ident #ty_generics #where_clause {
             #[inline]
             fn none() -> Self::Abi {
@@ -133,6 +137,7 @@ fn expand_into_wasm_abi(cont: &Container) -> TokenStream {
             }
         }
 
+        #[automatically_derived]
         impl #impl_generics From<#ident #ty_generics> for JsValue #where_clause {
             #[inline]
             fn from(value: #ident #ty_generics) -> Self {
@@ -153,6 +158,7 @@ fn expand_into_wasm_abi(cont: &Container) -> TokenStream {
             }
         }
 
+        #[automatically_derived]
         impl #impl_generics VectorIntoWasmAbi for #ident #ty_generics #where_clause {
             type Abi = <JsType as VectorIntoWasmAbi>::Abi;
 
@@ -196,6 +202,7 @@ fn expand_from_wasm_abi(cont: &Container) -> TokenStream {
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     quote! {
+        #[automatically_derived]
         impl #impl_generics FromWasmAbi for #ident #ty_generics #where_clause {
             type Abi = <JsType as FromWasmAbi>::Abi;
 
@@ -209,6 +216,7 @@ fn expand_from_wasm_abi(cont: &Container) -> TokenStream {
             }
         }
 
+        #[automatically_derived]
         impl #impl_generics OptionFromWasmAbi for #ident #ty_generics #where_clause {
             #[inline]
             fn is_none(js: &Self::Abi) -> bool {
@@ -218,6 +226,7 @@ fn expand_from_wasm_abi(cont: &Container) -> TokenStream {
 
         pub struct SelfOwner<T>(T);
 
+        #[automatically_derived]
         impl<T> ::core::ops::Deref for SelfOwner<T> {
             type Target = T;
 
@@ -226,6 +235,7 @@ fn expand_from_wasm_abi(cont: &Container) -> TokenStream {
             }
         }
 
+        #[automatically_derived]
         impl #impl_generics RefFromWasmAbi for #ident #ty_generics #where_clause {
             type Abi = <JsType as RefFromWasmAbi>::Abi;
 
@@ -240,6 +250,7 @@ fn expand_from_wasm_abi(cont: &Container) -> TokenStream {
             }
         }
 
+        #[automatically_derived]
         impl #impl_generics VectorFromWasmAbi for #ident #ty_generics #where_clause {
             type Abi = <JsType as VectorFromWasmAbi>::Abi;
 


### PR DESCRIPTION
`#[automatically_derived]` works only on impls, not blocks. This PR attaches the attribute on all generated impls.

See: https://doc.rust-lang.org/reference/attributes/derive.html#the-automatically_derived-attribute
https://github.com/rust-lang/rust/pull/120185


I was investigating https://github.com/madonoharu/tsify/issues/42, and the issue turned out to be `#[automatically_derived]` attributes being used on blocks that contains the impls, when it has to be used on the impls itself.

Although that issue turned out to be from wasm-bindgen crate (already fixed, but not yet published in https://github.com/rustwasm/wasm-bindgen/pull/4078), I thought I would fix the same problems on this repo too.


