### PR TITLE
Emit a compiler error if neither the json or the js features are enabled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,10 @@
 #![allow(clippy::wrong_self_convention)]
 
+#[cfg(not(any(feature = "json", feature = "js")))]
+compile_error!(
+    "Either the \"json\" or \"js\" feature must be enabled for tsify to function properly"
+);
+
 #[cfg(all(feature = "json", not(feature = "js")))]
 pub use gloo_utils::format::JsValueSerdeExt;
 #[cfg(feature = "js")]


### PR DESCRIPTION
I migrated some code from tsify to tsify-next and was scratching my head at all the compiler errors like

```
const `CONFIG` is not a member of trait `Tsify`
```

and

```
associated constant in `impl` without body
```

Turns out, I was using tsify with no enabled features, as the code in question was purely a library worked without any features.

It looks like this has changed (which is fine), and if tsify now requires an enabled feature (to support `SERIALIZATION_CONFIG`), better to emit a nice compile error.