### PR TITLE
Create a new version with deprecation statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # tsify-next Changelog
 
+## v0.5.6
+- Deprecate in favor of `tsify`. The main `tsify` project now has all changes from `tsify-next` merged in.
+
 ## v0.5.5
 
 - Don't assume a struct named `Range` is automatically a `Range` type

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsify-next"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 authors = [
   "Madono Haru <madonoharu@gmail.com>",
@@ -14,7 +14,7 @@ keywords = ["wasm", "wasm-bindgen", "typescript"]
 categories = ["wasm"]
 
 [dependencies]
-tsify-next-macros = { path = "tsify-next-macros", version = "0.5.5" }
+tsify-next-macros = { path = "tsify-next-macros", version = "0.5.6" }
 wasm-bindgen = { version = "0.2.100", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# (Deprecated)
+
+[Tsify](https://github.com/madonoharu/tsify) now has all the features of `tsify-next`; `tsify-next` has served its purpose and will no longer receive updates. Use `tsify` instead.
+
 # Tsify-next
 
 Tsify-next is a library for generating TypeScript definitions from Rust code. The original [Tsify](https://github.com/madonoharu/tsify) appears to be in hibernation mode. This repository will maintain updates until main Tsify project comes back to life.

--- a/tsify-next-macros/Cargo.toml
+++ b/tsify-next-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsify-next-macros"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 authors = [
     "Madono Haru <madonoharu@gmail.com>",


### PR DESCRIPTION
`tsify` is now back under development, so `tsify-next` is no longer needed.