### PR TITLE
Add workflow cron job to check for wasm-bindgen macro chagnes

### DIFF
--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -21,7 +21,7 @@ jobs:
 
         steps:
             - name: Checkout sources
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup Node.js
               uses: actions/setup-node@v4

--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -77,7 +77,7 @@ jobs:
                   git diff --quiet || {
                     git add .
                     git commit -m "Update expanded test artifacts"
-                    git push --set-upstream origin update-expanded-test-artifacts || true
+                    git push --set-upstream origin update-expanded-test-artifacts
                     gh pr create --fill || true
                   }
               env:

--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -1,0 +1,64 @@
+name: Check wasm-bindgen changes
+
+# Tests expand macro output. This changes a lot based on the version of wasm-bindgen that is installed
+# This cron job is meant to create a PR whenever there are changes to the expanded macro output.
+# Since all PRs that affect tsify's macro output should update their own tests, this should only detect
+# changes in other rust crates.
+
+on:
+    schedule:
+        - cron: "0 0 * * *" # every day at midnight GMT
+    workflow_dispatch:
+    push:
+        branches: [main, next]
+    pull_request:
+        branches: ["*"]
+
+jobs:
+    test:
+        name: Create Test Artifacts
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout sources
+              uses: actions/checkout@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "24"
+
+            - name: Install toolchain
+              uses: actions-rs/toolchain@v1
+              with:
+                  profile: minimal
+                  toolchain: stable
+                  override: true
+                  components: rustfmt
+
+            - name: Install wasm-pack
+              uses: jetli/wasm-pack-action@v0.4.0
+              with:
+                  # specify exact version to work around
+                  # https://github.com/jetli/wasm-pack-action/issues/23
+                  version: v0.13.1
+
+            - name: Add cargo-expand
+              run: cargo install cargo-expand
+
+            # Run `MACROTEST=overwrite cargo test -p tsify --test expandtest` to rebuild the test artifacts with expanded macros.
+            - name: Expand Macros
+              run: cargo test -p tsify --test expandtest
+              env:
+                  MACROTEST: overwrite
+
+            - name: Check for changes
+              run: |
+                  git diff --quiet || {
+                    git add .
+                    git commit -m "Update expanded test artifacts"
+                    git push --set-upstream origin update-expanded-test-artifacts || true
+                    gh pr create --fill || true
+                  }
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -78,7 +78,7 @@ jobs:
                     echo "Remote configuration:"
                     git remote -v
                     echo "Creating PR with changes..."
-                    git add .
+                    git add tests
                     git commit -m "Update expanded test artifacts"
                     git push --force --set-upstream origin update-expanded-test-artifacts
                     gh pr create --fill

--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -61,6 +61,7 @@ jobs:
                   # Fetch the branch from the remote
                   git fetch origin update-expanded-test-artifacts
                   git fetch origin ${{ env.TARGET_BRANCH }}
+                  git fetch origin main
                   # Reset to the target branch to avoid conflicts with the existing branch
                   git reset --hard origin/${{ env.TARGET_BRANCH }}
                   git branch --set-upstream-to=origin/${{ env.TARGET_BRANCH }} update-expanded-test-artifacts
@@ -76,8 +77,11 @@ jobs:
             - name: Check for changes
               run: |
                   git diff --quiet || {
+                    echo "Available branches:"
                     git branch -a
+                    echo "Remote configuration:"
                     git remote -v
+                    echo "Creating PR with changes..."
                     git add .
                     git commit -m "Update expanded test artifacts"
                     git push --force --set-upstream origin update-expanded-test-artifacts

--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -76,10 +76,9 @@ jobs:
             - name: Check for changes
               run: |
                   git diff --quiet || {
-                    git pull
                     git add .
                     git commit -m "Update expanded test artifacts"
-                    git push --set-upstream origin update-expanded-test-artifacts
+                    git push --force --set-upstream origin update-expanded-test-artifacts
                     gh pr create --fill || true
                   }
               env:

--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -14,6 +14,9 @@ on:
     pull_request:
         branches: ["*"]
 
+env:
+    TARGET_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
+
 jobs:
     test:
         name: Create Test Artifacts
@@ -57,9 +60,9 @@ jobs:
                   }
                   # Fetch the branch from the remote
                   git fetch origin update-expanded-test-artifacts
-                  git fetch origin main
-                  # make sure we match main
-                  git reset --hard origin/${{ github.event.pull_request.base.ref }}
+                  git fetch origin ${{ env.TARGET_BRANCH }}
+                  # Reset to the target branch to avoid conflicts with the existing branch
+                  git reset --hard origin/${{ env.TARGET_BRANCH }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -46,6 +46,23 @@ jobs:
             - name: Add cargo-expand
               run: cargo install cargo-expand
 
+            - name: Setup git config
+              run: |
+                  git config user.name "${{ github.actor }} via GitHub Actions"
+                  git config user.email "${{ github.actor }}@github_actions.no_reply"
+                  git checkout -b update-expanded-test-artifacts
+                  # Ensure the branch exists on the remote
+                  git ls-remote --exit-code origin update-expanded-test-artifacts || {
+                    git push -u origin update-expanded-test-artifacts
+                  }
+                  # Fetch the branch from the remote
+                  git fetch origin update-expanded-test-artifacts
+                  git fetch origin main
+                  # make sure we match main
+                  git reset --hard origin/main
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
             # Run `MACROTEST=overwrite cargo test -p tsify --test expandtest` to rebuild the test artifacts with expanded macros.
             - name: Expand Macros
               run: cargo test -p tsify --test expandtest

--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -9,10 +9,6 @@ on:
     schedule:
         - cron: "0 0 * * *" # every day at midnight GMT
     workflow_dispatch:
-    push:
-        branches: [main, next]
-    pull_request:
-        branches: ["*"]
 
 env:
     TARGET_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}

--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -63,6 +63,7 @@ jobs:
                   git fetch origin ${{ env.TARGET_BRANCH }}
                   # Reset to the target branch to avoid conflicts with the existing branch
                   git reset --hard origin/${{ env.TARGET_BRANCH }}
+                  git branch --set-upstream-to=origin/${{ env.TARGET_BRANCH }} update-expanded-test-artifacts
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -76,10 +76,12 @@ jobs:
             - name: Check for changes
               run: |
                   git diff --quiet || {
+                    git branch -a
+                    git remote -v
                     git add .
                     git commit -m "Update expanded test artifacts"
                     git push --force --set-upstream origin update-expanded-test-artifacts
-                    gh pr create --fill || true
+                    gh pr create --fill
                   }
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -75,6 +75,7 @@ jobs:
             - name: Check for changes
               run: |
                   git diff --quiet || {
+                    git pull
                     git add .
                     git commit -m "Update expanded test artifacts"
                     git push --set-upstream origin update-expanded-test-artifacts

--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -59,7 +59,7 @@ jobs:
                   git fetch origin update-expanded-test-artifacts
                   git fetch origin main
                   # make sure we match main
-                  git reset --hard ${{ github.event.pull_request.base.ref }}
+                  git reset --hard origin/${{ github.event.pull_request.base.ref }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -59,7 +59,7 @@ jobs:
                   git fetch origin update-expanded-test-artifacts
                   git fetch origin main
                   # make sure we match main
-                  git reset --hard origin/main
+                  git reset --hard ${{ github.event.pull_request.base.ref }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -13,7 +13,7 @@ jobs:
 
         steps:
             - name: Checkout sources
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install toolchain
               uses: actions-rs/toolchain@v1
@@ -37,12 +37,12 @@ jobs:
 
         steps:
             - name: Checkout sources
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: '20'
+                  node-version: '24'
 
             - name: Install toolchain
               uses: actions-rs/toolchain@v1

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -13,7 +13,7 @@ jobs:
 
         steps:
             - name: Checkout sources
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Install toolchain
               uses: actions-rs/toolchain@v1

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -37,7 +37,7 @@ jobs:
 
         steps:
             - name: Checkout sources
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup Node.js
               uses: actions/setup-node@v4
@@ -71,7 +71,7 @@ jobs:
 
         steps:
             - name: Checkout sources
-              uses: actions/checkout@v3
+              uses: actions/checkout@v6
 
             - name: Install toolchain
               uses: actions-rs/toolchain@v1

--- a/tests/expandtest.rs
+++ b/tests/expandtest.rs
@@ -1,6 +1,6 @@
 //! Generates expanded code for tests in `tests/expand/` directory.
 //! To update the expected output, run with `MACROTEST=overwrite cargo test`
-//! or delete the `.expanded.rs` files.
+//! or delete the `*.expanded.rs` files.
 
 #[test]
 fn expandtest() {


### PR DESCRIPTION
Tests expand macro output. This changes a lot based on the version of wasm-bindgen that is installed. This cron job is meant to create a PR whenever there are changes to the expanded macro output. Since all PRs that affect tsify's macro output should update their own tests, this should only detect changes in other rust crates.